### PR TITLE
fix: allow any React version >=16.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
This allows the package to be installed with React 17+ under npm v7, without `--legacy-peer-deps`