### PR TITLE
Fix: Failed to resolve entry for package "react-window-scroller". The package may have incorrect main/module/exports specified in its package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "author": "FedericoDiRosa",
   "license": "MIT",
   "repository": "FedericoDiRosa/react-window-scroller",
-  "main": "dist/index.jsx.js",
-  "module": "dist/index.modern.jsx.js",
-  "source": "src/index.jsx.js",
+  "main": "dist/index.jsx",
+  "module": "dist/index.jsx.modern",
+  "source": "src/index.jsx",
   "engines": {
     "node": ">=10"
   },

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "author": "FedericoDiRosa",
   "license": "MIT",
   "repository": "FedericoDiRosa/react-window-scroller",
-  "main": "dist/index.jsx",
-  "module": "dist/index.modern.jsx",
-  "source": "src/index.jsx",
+  "main": "dist/index.jsx.js",
+  "module": "dist/index.modern.jsx.js",
+  "source": "src/index.jsx.js",
   "engines": {
     "node": ">=10"
   },


### PR DESCRIPTION
This MR fixes the bug in Vite applications mentioned in this issue #27 