### PR TITLE
Add React 17 to Peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
Package.json only lists `^16.8.0` as being compatible. with this library. I updated the peer dependencies so I don't get any problems with npm install.

When I try and install this library in my project I get an error similar to:

```
npm WARN Could not resolve dependency:
npm WARN peer react@"^16.8.0" from react-window-scroller@1.0.10
npm WARN node_modules/react-window-scroller
npm WARN   react-window-scroller@"1.0.10" from the root project
npm WARN 
npm WARN Conflicting peer dependency: react@16.14.0
npm WARN node_modules/react
npm WARN   peer react@"^16.8.0" from react-window-scroller@1.0.10
npm WARN   node_modules/react-window-scroller
npm WARN     react-window-scroller@"1.0.10" from the root project
```

This change fixes this.